### PR TITLE
 Add the build_id to KojiTagChange messages (FACTORY-2825)

### DIFF
--- a/conf/config.py
+++ b/conf/config.py
@@ -22,6 +22,7 @@ message_mapping = {
         'msg_id': 'headers.message-id',
         'tag': 'body.tag.name',
         'artifact': 'body.build.name',
+        'build_id': 'body.build.build_id',
     },
     'KojiRepoChange': {
         'matches': ['/topic/VirtualTopic.eng.brew.repo.done'],

--- a/mbs_messaging_umb/parser.py
+++ b/mbs_messaging_umb/parser.py
@@ -22,6 +22,7 @@
 # Written by Mike Bonnet <mikeb@redhat.com>
 
 import logging
+import inspect
 import fnmatch
 import jsonpath_rw
 from conf import load_config
@@ -95,9 +96,15 @@ class CustomParser(object):
             try:
                 return msg_cls(**attrs)
             except:
+                accepted_args = inspect.getargspec(msg_cls.__init__).args
+                # Remove 'self' from the accepted arguments
+                accepted_args.pop(0)
+                error = ('Error constructing {0}. The args of the constructor '
+                         'are: {1}. The args passed in were (not in order): {2}'
+                         .format(cls_name, ', '.join(accepted_args),
+                                 ', '.join(attrs.keys())))
                 # incorrect number of parameters passed to the constructor, probably
-                self.log.exception('Error constructing %s, is the number of '
-                                   'parameters correct?', cls_name)
+                self.log.exception(error)
                 continue
 
         # nothing worked


### PR DESCRIPTION
This is in relation to:
https://pagure.io/fm-orchestrator/pull-request/981

This also adds more debug information when a message class fails to instantiate. This will help us diagnose issues in MBS in the future (we currently see this error a lot but it doesn't seem to affect builds).