### PR TITLE
Silence a spammy error.

### DIFF
--- a/mbs_messaging_umb/parser.py
+++ b/mbs_messaging_umb/parser.py
@@ -95,6 +95,9 @@ class CustomParser(object):
                 continue
             try:
                 return msg_cls(**attrs)
+            except module_build_service.messaging.IgnoreMessage as e:
+                # These are harmless
+                self.log.debug(e)
             except Exception:
                 accepted_args = inspect.getargspec(msg_cls.__init__).args
                 # Remove 'self' from the accepted arguments


### PR DESCRIPTION
These used to show up as `log.exception(...)` tracebacks in the logs,
but they are harmless and make it hard to read the logs looking for real
errors.