### PR TITLE
Add support for stomp.py v4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 jsonpath-rw
 module-build-service
-stomp.py == 3.1.6
+stomp.py >= 3.1.6, < 5.0.0

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -21,7 +21,6 @@
 # Written by Mike Bonnet <mikeb@redhat.com>
 
 
-import unittest
 from copy import deepcopy
 # XXX horrible hack to get tests running in travis-ci
 # remove when koji is in pypi
@@ -36,7 +35,7 @@ from mock import patch, MagicMock
 from mbs_messaging_umb.parser import CustomParser
 
 
-class TestCustomParser(unittest.TestCase):
+class TestCustomParser(object):
 
     repo_msg = {
         'topic': '/topic/VirtualTopic.koji.repo.done',
@@ -60,71 +59,71 @@ class TestCustomParser(unittest.TestCase):
     }
 
     @patch('mbs_messaging_umb.parser.load_config')
-    def setUp(self, load_conf):
+    def setup_method(self, test_method, load_conf):
         load_conf.return_value = MagicMock(message_mapping=deepcopy(self.repo_mapping))
         self.parser = CustomParser()
 
     def test_koji_repo_msg(self):
         msg = self.parser.parse(self.repo_msg)
-        self.assertIsInstance(msg, KojiRepoChange)
-        self.assertEqual(msg.msg_id, self.repo_msg['headers']['message-id'])
-        self.assertEqual(msg.repo_tag, self.repo_msg['msg']['repo']['tag_name'])
+        assert isinstance(msg, KojiRepoChange)
+        assert msg.msg_id == self.repo_msg['headers']['message-id']
+        assert msg.repo_tag == self.repo_msg['msg']['repo']['tag_name']
 
         # make sure it works when 'matches' is a string too
         self.parser.conf.message_mapping['KojiRepoChange']['matches'] \
             = '/topic/VirtualTopic.koji.repo.done'
         msg = self.parser.parse(self.repo_msg)
-        self.assertIsInstance(msg, KojiRepoChange)
-        self.assertEqual(msg.msg_id, self.repo_msg['headers']['message-id'])
-        self.assertEqual(msg.repo_tag, self.repo_msg['msg']['repo']['tag_name'])
+        assert isinstance(msg, KojiRepoChange)
+        assert msg.msg_id == self.repo_msg['headers']['message-id']
+        assert msg.repo_tag == self.repo_msg['msg']['repo']['tag_name']
 
     def test_koji_repo_msg_wildcard(self):
         self.parser.conf.message_mapping['KojiRepoChange']['matches'] = [
             '/topic/VirtualTopic.koji.repo.*'
         ]
         msg = self.parser.parse(self.repo_msg)
-        self.assertIsInstance(msg, KojiRepoChange)
-        self.assertEqual(msg.msg_id, self.repo_msg['headers']['message-id'])
-        self.assertEqual(msg.repo_tag, self.repo_msg['msg']['repo']['tag_name'])
+        assert isinstance(msg, KojiRepoChange)
+        assert msg.msg_id == self.repo_msg['headers']['message-id']
+        assert msg.repo_tag == self.repo_msg['msg']['repo']['tag_name']
 
     def test_koji_repo_msg_noattrs(self):
         repo_msg = {
             'topic': '/topic/VirtualTopic.koji.repo.done',
         }
         msg = self.parser.parse(repo_msg)
-        self.assertIsInstance(msg, KojiRepoChange)
-        self.assertIsNone(msg.msg_id)
-        self.assertIsNone(msg.repo_tag)
+        assert isinstance(msg, KojiRepoChange)
+        assert msg.msg_id is None
+        assert msg.repo_tag is None
 
     def test_koji_repo_msg_no_topic_mapping(self):
         del self.parser.conf.message_mapping['KojiRepoChange']['topic']
         msg = self.parser.parse(self.repo_msg)
-        self.assertIsNone(msg)
+        assert msg is None
 
     def test_koji_repo_msg_no_matches_mapping(self):
         del self.parser.conf.message_mapping['KojiRepoChange']['matches']
         msg = self.parser.parse(self.repo_msg)
-        self.assertIsNone(msg)
+        assert msg is None
 
     def test_koji_repo_msg_no_topic(self):
         repo_msg = self.repo_msg.copy()
         del repo_msg['topic']
         msg = self.parser.parse(repo_msg)
-        self.assertIsNone(msg)
+        assert msg is None
 
     def test_koji_repo_msg_nomatch(self):
         self.parser.conf.message_mapping['KojiRepoChange']['matches'] = [
             '/topic/VirtualTopic.koji.repo.foo'
         ]
         msg = self.parser.parse(self.repo_msg)
-        self.assertIsNone(msg)
+        assert msg is None
 
     def test_koji_repo_msg_noclass(self):
         self.parser.conf.message_mapping['FooBar'] \
             = self.parser.conf.message_mapping['KojiRepoChange']
         del self.parser.conf.message_mapping['KojiRepoChange']
         msg = self.parser.parse(self.repo_msg)
-        self.assertIsNone(msg)
+        assert msg is None
 
     def test_koji_repo_msg_incorrect_params(self):
         repo_msg = deepcopy(self.repo_msg)
@@ -132,4 +131,4 @@ class TestCustomParser(unittest.TestCase):
         self.parser.conf.message_mapping['KojiRepoChange']['foo'] \
             = 'msg.foo'
         msg = self.parser.parse(repo_msg)
-        self.assertIsNone(msg)
+        assert msg is None


### PR DESCRIPTION
The first commit fully migrates the tests to `pytest` so that the next commit can use `pytest.mark.parametrize`. The second commit is the actual implementation of this PR.

The tests pass locally but I imagine they won't pass in Travis CI due to new dependencies in MBS that aren't available from PyPi. In a future PR, we should likely migrate the tests to run in a container.