### PR TITLE
Use a container to run the tests in TravisCI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .tox/
 .coverage
 .coverage.*
+
+mbs_messaging_umb.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,7 @@
-language: python
-addons:
-  apt:
-    packages:
-      - swig
-python:
- - "2.7"
-env:
-  - TOXENV=py27
-  - TOXENV=flake8
-  - TOXENV=bandit
-  - TOXENV=coverage
-install: pip install tox-travis codecov
-script: tox
-after_success: >
-  [ -f $TRAVIS_BUILD_DIR/.coverage ] &&
-  coverage xml -o $TRAVIS_BUILD_DIR/coverage.xml &&
-  codecov -e TRAVIS_PYTHON_VERSION --file $TRAVIS_BUILD_DIR/coverage.xml || :
+language: generic
+sudo: required
+services: docker
+install:
+  - docker build -t mbs-messaging-umb-tests -f Dockerfile-tests .
+script:
+  - docker run -v $PWD:/src:Z mbs-messaging-umb-tests

--- a/Dockerfile-tests
+++ b/Dockerfile-tests
@@ -1,0 +1,23 @@
+FROM centos:7
+
+RUN yum -y update
+RUN yum -y install epel-release yum-utils
+# This repo contains the latest version of MBS
+RUN yum-config-manager --add-repo https://kojipkgs.fedoraproject.org/repos-dist/epel7Server-infra/latest/x86_64/
+RUN yum -y install \
+    --nogpgcheck \
+    --setopt=deltarpm=0 \
+    --setopt=install_weak_deps=false \
+    --setopt=tsflags=nodocs \
+    module-build-service \
+    python-jsonpath-rw \
+    python-pip \
+    python-tox \
+    rpm-devel \
+    stomppy \
+    && yum clean all
+# We currently require newer versions of these Python packages for the tests
+RUN pip install --upgrade pip tox
+VOLUME /src
+WORKDIR /src
+CMD ["tox", "-r"]

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Build Status
 Running the Tests
 -----------------
 
-    # install the test tool
-    $ sudo dnf install python2-detox
-    # Run it.
-    $ detox
-
-If detox is unavailable on your system, you can also use plain old tox.
+    # Install Docker
+    $ sudo dnf install docker
+    # Build the container
+    $ sudo docker build -t mbs-messaging-umb-tests -f Dockerfile-tests .
+    # Run the tests
+    $ sudo docker run -it -v $PWD:/src:Z mbs-messaging-umb-tests

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -20,19 +20,16 @@
 #
 # Written by Mike Bonnet <mikeb@redhat.com>
 
-
 from copy import deepcopy
-# XXX horrible hack to get tests running in travis-ci
-# remove when koji is in pypi
-# For more info, see:
-# https://lists.fedoraproject.org/archives/list/koji-devel@lists.fedorahosted.org/thread/XLIR4DSXXRU3OYWXEZWJQJAEEIOUQEXY/
-# koji is targeted for inclusion in pypi during the 1.15 development cycle.
-import sys
-sys.modules['kobo.rpmlib'] = ''
-# XXX
-from module_build_service.messaging import KojiRepoChange
 from mock import patch, MagicMock
 from mbs_messaging_umb.parser import CustomParser
+
+
+# A horrible hack to avoid MBS from detecting pytest is running and using a
+# test configuration that is not available as part of the RPM. See
+# `module_build_service.config.init_config` for more information.
+with patch('sys.argv'):
+    from module_build_service.messaging import KojiRepoChange
 
 
 class TestCustomParser(object):

--- a/tox.ini
+++ b/tox.ini
@@ -7,12 +7,10 @@
 envlist = py27, coverage, flake8, bandit
 
 [testenv]
-# using sitepackages is not a good idea, but Koji... :(
+# Using sitepackages is required for the module-build-service dependency
+usedevelop = true
 sitepackages = True
-install_command = pip install --force-reinstall --ignore-installed {packages}
-deps =
-    mock
-    pytest
+deps = -r{toxinidir}/test-requirements.txt
 commands = py.test {posargs}
 setenv = MBS_MESSAGING_UMB_CONFIG={toxinidir}/conf/config.py
 


### PR DESCRIPTION
Since MBS (a dependency of this project) now requires a lot of dependencies not available through PyPi, we have to use a container for running the tests in TravisCI.