### PR TITLE
Fix py2.7 tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.env/
+.tox/
+htmlcov/

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@
 .coverage
 .coverage.*
 
+.env/
+.idea/
+htmlcov/
 mbs_messaging_umb.egg-info/

--- a/Dockerfile-tests
+++ b/Dockerfile-tests
@@ -17,7 +17,7 @@ RUN yum -y install \
     stomppy \
     && yum clean all
 # We currently require newer versions of these Python packages for the tests
-RUN pip install --upgrade pip tox
+RUN pip install --upgrade pip tox && pip install -I "more-itertools<6.0.0"
 VOLUME /src
 WORKDIR /src
 CMD ["tox", "-r", "-e", "py27,coverage,flake8,bandit"]

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ commands = flake8
 [flake8]
 max-line-length = 100
 ignore = E402
+exclude = .env,.tox,.idea,build,dist,.pytest_cache,htmlcov,*.egg-info,__pycache__
 
 [testenv:bandit]
 basepython = python2


### PR DESCRIPTION
Latest version of more-itertools breaks tox when run with Python 2.7, because since version 6.0.0, more-itertools drops Python 2.7.

This PR also includes some other minor changes found and made during preparing this PR.