### PR TITLE
remove module-build-service from the test Dockerfiles

### DIFF
--- a/Dockerfile-tests
+++ b/Dockerfile-tests
@@ -1,20 +1,16 @@
 FROM centos:7
 
-RUN yum -y update
-RUN yum -y install epel-release yum-utils
-# This repo contains the latest version of MBS
-RUN yum-config-manager --add-repo https://kojipkgs.fedoraproject.org/repos-dist/epel7Server-infra/latest/x86_64/
-RUN yum -y install \
+RUN yum -y install epel-release && \
+    yum -y install \
     --nogpgcheck \
     --setopt=deltarpm=0 \
     --setopt=install_weak_deps=false \
     --setopt=tsflags=nodocs \
-    module-build-service \
     python-jsonpath-rw \
     python-pip \
     python-tox \
-    rpm-devel \
     stomppy \
+    python2-fedmsg \
     && yum clean all
 # We currently require newer versions of these Python packages for the tests
 RUN pip install --upgrade pip tox && pip install -I "more-itertools<6.0.0"

--- a/Dockerfile-tests-py3
+++ b/Dockerfile-tests-py3
@@ -7,7 +7,7 @@ RUN dnf -y install \
     python3-tox \
     python3-stomppy \
     python3-jsonpath-rw \
-    module-build-service \
+    python3-fedmsg \
     && dnf clean all
 
 VOLUME /src

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 jsonpath-rw
-# module-build-service
 stomp.py >= 3.1.6, < 5.0.0


### PR DESCRIPTION
Since module-build-service is no longer required to run tests, don't
install it in the images we use to run tests.