### PR TITLE
Add retry when trying to get stomp connection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
-language: generic
+language: python
+python:
+  - "3.9"
 sudo: required
 services: docker
+dist: jammy
+before_install:
+  - sudo apt-get update
+  - sudo apt-get -y install podman
 install:
-  - docker build --no-cache -t mbs-messaging-umb-tests-py3 -f Dockerfile-tests-py3 .
+  - sudo podman build --no-cache -t mbs-messaging-umb-tests-py3 -f Dockerfile-tests-py3 .
 script:
-  - docker run -v $PWD:/src:Z mbs-messaging-umb-tests-py3
+  - sudo podman run -v $PWD:/src:Z mbs-messaging-umb-tests-py3

--- a/Dockerfile-tests-py3
+++ b/Dockerfile-tests-py3
@@ -13,4 +13,4 @@ RUN dnf -y install \
 
 VOLUME /src
 WORKDIR /src
-CMD ["tox", "-r", "-e", "py39,coverage,flake8,bandit"]
+CMD ["tox", "-r", "-e", "py3,coverage,flake8,bandit"]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py39, coverage, flake8, bandit
+envlist = py3, coverage, flake8, bandit
 
 [testenv]
 # Using sitepackages is required for the module-build-service dependency


### PR DESCRIPTION
Retry when `ConnectFailedException` is raised while trying to get a stomp connection.
Max retries are set to 3.

@mikebonnet PTAL